### PR TITLE
fix(Facebook Profile Picture): Set image URL to https 

### DIFF
--- a/library/src/main/java/com/androidsocialnetworks/lib/impl/FacebookSocialNetwork.java
+++ b/library/src/main/java/com/androidsocialnetworks/lib/impl/FacebookSocialNetwork.java
@@ -153,7 +153,7 @@ public class FacebookSocialNetwork extends SocialNetwork {
                     socialPerson.id = me.getId();
                     socialPerson.name = me.getName();
                     socialPerson.avatarURL =
-                            String.format("http://graph.facebook.com/%s/picture?width=200&height=200", me.getId());
+                            String.format("https://graph.facebook.com/%s/picture?width=200&height=200", me.getId());
 
                     socialPerson.profileURL = me.getLink();
                     socialPerson.nickname = me.getUsername();


### PR DESCRIPTION
If `http` is used, the graph API image URL won't get redirected properly.