### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Library is still in development, so for now it's only available in staging repo.
 - [signpost-core](https://code.google.com/p/oauth-signpost/)
 - [signpost-commonshttp4](https://code.google.com/p/oauth-signpost/)
 
-##Developed By
+## Developed By
 
   Anton Krasov - <anton.krasov@gmail.com>
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
